### PR TITLE
fix X.691 §10.6 — CHOICE extension index encoded via range-dependent nsnnwn

### DIFF
--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -1060,7 +1060,7 @@ CHOICE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
 	} else {
 		if(specs->ext_start == -1)
 			ASN__DECODE_FAILED;
-		value = aper_get_nsnnwn(pd, ext_ct->range_bits);
+		value = aper_get_nsnnwn_ext(pd);
 		if(value < 0) ASN__DECODE_STARVED;
 		value += specs->ext_start;
 		if((unsigned)value >= td->elements_count)

--- a/skeletons/per_support.c
+++ b/skeletons/per_support.c
@@ -490,3 +490,39 @@ aper_put_nsnnwn(asn_per_outp_t *po, int range, int number) {
 */
     return per_put_few_bits(po, number, 8 * bytes);
 }
+
+/* True X.691 §10.6 nsnnwn — range-independent. For CHOICE extension indices only. */
+int
+aper_put_nsnnwn_ext(asn_per_outp_t *po, int number) {
+    int bytes;
+    if(number < 0) return -1;
+
+    if(number <= 63)
+        return per_put_few_bits(po, number, 7);   /* '0' + 6 bits */
+
+    if(number < 256)           bytes = 1;
+    else if(number < 65536)    bytes = 2;
+    else if(number < 16777216) bytes = 3;
+    else return -1;
+
+    if(per_put_few_bits(po, 1, 1))         return -1;
+    if(aper_put_align(po) < 0)             return -1;
+    if(aper_put_length(po, -1, bytes) < 0) return -1;
+    return per_put_few_bits(po, number, 8 * bytes);
+}
+
+ssize_t
+aper_get_nsnnwn_ext(asn_per_data_t *pd) {
+    ssize_t flagbit = per_get_few_bits(pd, 1);
+    if(flagbit < 0) return -1;
+
+    if(flagbit == 0)
+        return per_get_few_bits(pd, 6);           /* short form */
+
+    if(aper_get_align(pd) < 0) return -1;
+    int ebits = 0;
+    int repeat = 0;
+    ssize_t len = aper_get_length(pd, -1, ebits, &repeat);
+    if(len < 0 || len > 3) return -1;
+    return per_get_few_bits(pd, 8 * (int)len);
+}

--- a/skeletons/per_support.h
+++ b/skeletons/per_support.h
@@ -63,6 +63,16 @@ ssize_t aper_get_nslength(asn_per_data_t *pd);
 ssize_t uper_get_nsnnwn(asn_per_data_t *pd);
 ssize_t aper_get_nsnnwn(asn_per_data_t *pd, int range);
 
+/*
+ * X.691 (08/2015) #10.6 "Encoding of a normally small non-negative
+ * whole number"
+ * Range-independent variant, for use where the value has no
+ * associated range (e.g. CHOICE extension-alternative index).
+ * Distinct from aper_get_nsnnwn() above, which is range-aware and
+ * used for constrained length determinants (#10.9.3).
+ */
+ssize_t aper_get_nsnnwn_ext(asn_per_data_t *pd);
+
 /* X.691-2008/11, #11.5.6 */
 int uper_get_constrained_whole_number(asn_per_data_t *pd, unsigned long *v, int nbits);
 
@@ -119,6 +129,16 @@ int aper_put_nslength(asn_per_outp_t *po, size_t length);
 int uper_put_nsnnwn(asn_per_outp_t *po, int n);
 
 int aper_put_nsnnwn(asn_per_outp_t *po, int range, int number);
+
+/*
+ * X.691 (08/2015) #10.6 "Encoding of a normally small non-negative
+ * whole number"
+ * Range-independent variant, for use where the value has no
+ * associated range (e.g. CHOICE extension-alternative index).
+ * Distinct from aper_put_nsnnwn() above, which is range-aware and
+ * used for constrained length determinants (#10.9.3).
+ */
+int aper_put_nsnnwn_ext(asn_per_outp_t *po, int number);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
`CHOICE_encode_aper()`/`CHOICE_decode_aper()` encode the extension-alternative index using `aper_put_nsnnwn()`/`aper_get_nsnnwn()`, expecting X.691 §10.6 semantics (range-independent: 1-bit form flag + 6-bit short form or aligned long form). But these functions actually implement §10.9.3 (constrained length determinant) semantics, they take a `range` and pack the value into the minimum bits it implies, skipping the §10.6 form-indicator bit. That's correct for `aper_get_length()`'s use of them, but wrong for CHOICE extension indices, which have no range.

**Symptom:** any extensible CHOICE selecting a non-root alternative encodes with a corrupted leading bit. Concretely, an E2SM-RC `ControlHeader` selecting extension alternative `controlHeader-Format3` produced `0x60...` instead of the correct `0x41...`, which Wireshark flags as `too long integer (per_normally_small_nonnegative_whole_number)`.

**Fix:** add range-independent `aper_put_nsnnwn_ext()`/`aper_get_nsnnwn_ext()` implementing §10.6 encoding, and repoint only the two CHOICE call sites to them. `aper_get_length()` and the original `nsnnwn` functions are untouched.

**Files:** `per_support.h`/`.c` (new functions), `constr_CHOICE.c` (call sites).